### PR TITLE
Add Signal AI Digest - personalized AI news via Telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A curated list of top best AI Related Newsletters and ai agents newsletters.
 General
 --------
 
+- [Signal AI Digest](https://humanintel.github.io/signal-digest-landing/) - AI-curated daily Telegram digest. Set your topics (AI, tech, investing, crypto, world news) and receive 5-10 curated items with source citations every day.
 - [Altern Newsletter](http://newsletter.altern.ai) - Altern AI Newsletter
 - [AI For Developers](https://aifordevelopers.substack.com) - AI For Developers Newsletter
 - [Super Human](https://www.superhuman.ai/subscribe?ref=altern.ai) - Get the latest AI news, learn must-know AI tools, and keep up with tech news in just 3 minutes a day


### PR DESCRIPTION
Adding [Signal AI Digest](https://humanintel.github.io/signal-digest-landing/) to the General AI Newsletters section.

**What it is:** Signal AI Digest is an AI-curated daily news digest delivered via Telegram. Users set their topics (AI, tech, investing, crypto, world news, climate, etc.) and receive 5-10 curated items with source citations every day.

**Why it belongs here:** It's a genuinely useful AI-powered newsletter that delivers personalized, cited content daily. Free tier available (3 items/day), paid plan $5/month for full digest.

**Telegram bot:** @SignalDigest_Bot