### PR TITLE
Add TLDL newsletter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ General
 
 - [Altern Newsletter](http://newsletter.altern.ai) - Altern AI Newsletter
 - [AI For Developers](https://aifordevelopers.substack.com) - AI For Developers Newsletter
+- [TLDL](https://www.tldl.io) - Daily AI learning with podcast summaries, LLM pricing, and resources for engineers and founders.
 - [Super Human](https://www.superhuman.ai/subscribe?ref=altern.ai) - Get the latest AI news, learn must-know AI tools, and keep up with tech news in just 3 minutes a day
 - [There's an AI Newsletter](https://newsletter.theresanai.com) - The Best AI Newsletter
 - [AI Breakfast](https://aibreakfast.beehiiv.com/?ref=altern.ai) - Curated weekly analysis of the latest AI projects, products, and news.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ General
 
 - [Altern Newsletter](http://newsletter.altern.ai) - Altern AI Newsletter
 - [AI For Developers](https://aifordevelopers.substack.com) - AI For Developers Newsletter
-- [TLDL](https://www.tldl.io) - Daily AI learning with podcast summaries, LLM pricing, and resources for engineers and founders.
+- [TLDL](https://www.tldl.io) - Daily AI podcast summaries for engineers and founders. Stay ahead of the curve.
 - [Super Human](https://www.superhuman.ai/subscribe?ref=altern.ai) - Get the latest AI news, learn must-know AI tools, and keep up with tech news in just 3 minutes a day
 - [There's an AI Newsletter](https://newsletter.theresanai.com) - The Best AI Newsletter
 - [AI Breakfast](https://aibreakfast.beehiiv.com/?ref=altern.ai) - Curated weekly analysis of the latest AI projects, products, and news.


### PR DESCRIPTION
Add TLDL to the General AI Newsletters section.

TLDL is a daily AI learning resource with podcast summaries, and resources for engineers and founders.