### PR TITLE
Add Wired on AI to For Professionals section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For Professionals
 - [The ML Engineer Newsletter](https://ethical.institute/mle.html?ref=altern.ai). Receive updates on open source frameworks, tutorials and articles curated by machine learning professionals. Obtain insights on best practices, tools and techniques in machine learning explainability, reproducibility, model evaluation, feature analysis and beyond.
 - [True Positive Weekly](https://aiweekly.substack.com/?ref=altern.ai). The most important artificial intelligence and machine learning links of the week.
 - [The AI Evaluation Substack](https://aievaluation.substack.com/). Monthly curated digest of AI evaluation research.
-
+- [Wired on AI](https://wiredonai.ai) - Weekly newsletter covering the best AI tools, practical prompts, and what's actually working in AI. For professionals who want to work smarter without the hype.
 
 Policy &amp; Post-AI Society
 --------


### PR DESCRIPTION
Adding Wired on AI to the For Professionals section.

Wired on AI is a weekly newsletter covering the best AI tools, practical prompts, and what's actually working in AI. Published at wiredonai.ai.