### PR TITLE
Add Creative AI News to General section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ General
 - [Turing Post](https://www.turingpost.com/) - Newsletter exploring AI&ML - AI 101, Agentic Workflow, Business insights. From ML history to AI trends. 
 - [Techpresso](https://dupple.com/techpresso/) - The free daily email with the most interesting tech news and insights. The best way to stay ahead in just a few minutes.
 - [7min.ai](https://7min.ai/newsletter) - Daily AI news digest AI-curated from 20+ sources, prioritized by relevance, delivered in a 7-minute read. Neutral writing style.
+- [Creative AI News](https://www.creativeainews.com) - Weekly AI tools and workflows for every working creator: image, video, audio, 3D, and code.
 
 
 AI Tools


### PR DESCRIPTION
Adding [Creative AI News](https://www.creativeainews.com), a weekly newsletter covering AI tools and workflows for working creators across image, video, audio, 3D, and code.

Quick context:
- 411 published articles, weekly cadence
- Pillar guides covering AI Video, AI Image, ComfyUI, AI Coding, AI Music, and Open-Source AI
- Editorial focus on what ships for creators, not benchmark sheets

Added one line to the General section, matching the existing format.

This replaces #27, which I closed for revision; the new entry is shorter and clearer.